### PR TITLE
add automatic message telling user to update its plugins

### DIFF
--- a/src/main/java/eu/kennytv/viaeduard/util/EmbedMessageUtil.java
+++ b/src/main/java/eu/kennytv/viaeduard/util/EmbedMessageUtil.java
@@ -21,7 +21,7 @@ public final class EmbedMessageUtil {
     }
 
     public static void sendMessage(final TextChannel channel, final String message, final Color color) {
-        channel.sendMessage(getMessage(message, color)).queue();
+        channel.sendMessageEmbeds(getMessage(message, color)).queue();
     }
 
     public static void sendMessage(final TextChannel channel, final String message) {
@@ -37,7 +37,7 @@ public final class EmbedMessageUtil {
     }
 
     private static void sendTempMessage(final TextChannel channel, final Message message, final String error, final Color color) {
-        final Message msg = channel.sendMessage(EmbedMessageUtil.getMessage(error, color)).complete();
+        final Message msg = channel.sendMessageEmbeds(EmbedMessageUtil.getMessage(error, color)).complete();
         message.delete().queueAfter(5, TimeUnit.SECONDS);
         msg.delete().queueAfter(5, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
This adds a message mentioning the user to update its Via plugins when we detect one of them is outdated.

Exemple: 

> @tomcraft Please update ViaVersion, ViaBackwards and ViaRewind from #links, it may fix your issue.
> If it doesn't, send a new dump to this channel for a human to help you.

Other changes are trivial, like moving where the "radioactive" emote is added and JDA deprecation replacements.

I did not test these changes because I don't have any environnement to test them.

If someone is more inspired about the text or formatting of the message, suggestions are open.
Also, tell me if something is wrong about these changes or if you think something else could be done instead.