### PR TITLE
add warning when ViaRewind is installed but ViaBackwards is not on >1.9 servers

### DIFF
--- a/src/main/java/eu/kennytv/viaeduard/listener/DumpMessageListener.java
+++ b/src/main/java/eu/kennytv/viaeduard/listener/DumpMessageListener.java
@@ -161,6 +161,13 @@ public final class DumpMessageListener extends ListenerAdapter {
                     }
                 }
             }
+
+            final int serverProtocol = object.getAsJsonPrimitive("serverProtocol").getAsInt();
+            if (serverProtocol > 107 // serverProtocol > 1.9
+                    && compareResults.stream().anyMatch(r -> r.pluginName.equals("ViaRewind"))
+                    && compareResults.stream().noneMatch(r -> r.pluginName.equals("ViaBackwards"))) {
+                EmbedMessageUtil.sendMessage(message.getTextChannel(), "It looks like you are missing the ViaBackwards plugin. Please install it from <#698284788074938388> if you need older versions to join, or delete the ViaRewind plugin.", Color.RED);
+            }
         }
 
         // Add Radioactive reaction for heavily outdated plugins


### PR DESCRIPTION
This adds an automatic message asking to install ViaBackwards or removing ViaRewind when the ViaRewind plugin is installed but ViaBackwards is not on >1.9 servers, because in this setup ViaRewind is useless.