### PR TITLE
Improve detection of the dump url

### DIFF
--- a/src/main/java/eu/kennytv/viaeduard/listener/DumpMessageListener.java
+++ b/src/main/java/eu/kennytv/viaeduard/listener/DumpMessageListener.java
@@ -43,7 +43,7 @@ public final class DumpMessageListener extends ListenerAdapter {
 
     @Override
     public void onMessageReceived(@NotNull final MessageReceivedEvent event) {
-        if (!event.isFromGuild() || !event.isFromType(ChannelType.TEXT) || event.isWebhookMessage()) {
+        if (!event.isFromGuild() || !event.isFromType(ChannelType.TEXT) || event.isWebhookMessage() || event.getAuthor().isBot()) {
             return;
         }
 
@@ -66,6 +66,7 @@ public final class DumpMessageListener extends ListenerAdapter {
         if (end == -1) {
             end = line.indexOf(' ');
         }
+        line = line.replace(")", "");
 
         line = line.substring(0, end == -1 ? line.length() : end);
         if (line.length() == 28) {


### PR DESCRIPTION
With this PR masked dump links like `[superDump](https://dump.viaversion.com/b157bfa36b34680aee0c05ec796ed31c04ad682551d769054a43517c60a7b102)` are now also detected. 
Also the dump check is skipped on messages from bots