### PR TITLE
Move links channel into config, added different support channels

### DIFF
--- a/src/main/java/eu/kennytv/viaeduard/ViaEduardBot.java
+++ b/src/main/java/eu/kennytv/viaeduard/ViaEduardBot.java
@@ -41,7 +41,10 @@ public final class ViaEduardBot {
     private final JDA jda;
     private final Guild guild;
     private long botChannelId;
-    private long supportChannelId;
+    private long pluginSupportChannelId;
+    private long modSupportChannelId;
+    private long proxySupportChannelId;
+    private long linksChannelId;
     private Set<Long> nonSupportChannelIds;
     private String[] trackedBranches;
     private String privateHelpMessage;
@@ -111,7 +114,10 @@ public final class ViaEduardBot {
             trackedBranches[i] = trackedBranchesArray.get(i).getAsString();
         }
 
-        supportChannelId = object.getAsJsonPrimitive("support-channel").getAsLong();
+        pluginSupportChannelId = object.getAsJsonPrimitive("plugin-support-channel").getAsLong();
+        modSupportChannelId = object.getAsJsonPrimitive("mod-support-channel").getAsLong();
+        proxySupportChannelId = object.getAsJsonPrimitive("proxy-support-channel").getAsLong();
+        linksChannelId = object.getAsJsonPrimitive("links-channel").getAsLong();
         nonSupportChannelIds = object.getAsJsonArray("not-support-channels").asList()
                 .stream().map(JsonElement::getAsLong).collect(java.util.stream.Collectors.toSet());
         botChannelId = object.getAsJsonPrimitive("bot-channel").getAsLong();
@@ -154,8 +160,20 @@ public final class ViaEduardBot {
         return botChannelId;
     }
 
-    public long getSupportChannelId() {
-        return supportChannelId;
+    public long getPluginSupportChannelId() {
+        return pluginSupportChannelId;
+    }
+
+    public long getModSupportChannelId() {
+        return modSupportChannelId;
+    }
+
+    public long getProxySupportChannelId() {
+        return proxySupportChannelId;
+    }
+
+    public long getLinksChannelId() {
+        return linksChannelId;
     }
 
     public Set<Long> getNonSupportChannelIds() {

--- a/src/main/java/eu/kennytv/viaeduard/listener/DumpMessageListener.java
+++ b/src/main/java/eu/kennytv/viaeduard/listener/DumpMessageListener.java
@@ -220,7 +220,7 @@ public final class DumpMessageListener extends ListenerAdapter {
                 if (serverProtocol > 107 // serverProtocol > 1.9
                         && compareResults.stream().anyMatch(r -> r.pluginName.equals("ViaRewind"))
                         && compareResults.stream().noneMatch(r -> r.pluginName.equals("ViaBackwards"))) {
-                    EmbedMessageUtil.sendMessage(message.getChannel(), "It looks like you are missing the ViaBackwards plugin. Please install it from <#698284788074938388> if you need older versions to join, or delete the ViaRewind plugin.", Color.RED);
+                    EmbedMessageUtil.sendMessage(message.getChannel(), "It looks like you are missing the ViaBackwards plugin. Please install it from <#" + bot.getLinksChannelId() + "> if you need older versions to join, or delete the ViaRewind plugin.", Color.RED);
                 }
             }
         }
@@ -247,7 +247,7 @@ public final class DumpMessageListener extends ListenerAdapter {
             } else {
                 updateMessage.append(platformType).append(" ").append(pluginsToUpdate.get(0));
             }
-            message.getChannel().sendMessage(message.getAuthor().getAsMention() + " Please update the " + updateMessage + " from <#698284788074938388>, it may fix your issue.\nIf it doesn't, send a new dump to this channel for a human to help you.").queue();
+            message.getChannel().sendMessage(message.getAuthor().getAsMention() + " Please update the " + updateMessage + " from <#" + bot.getLinksChannelId() + ">, it may fix your issue.\nIf it doesn't, send a new dump to this channel for a human to help you.").queue();
         }
     }
 

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -1,7 +1,10 @@
 {
   "token": "",
   "bot-channel": 698483428915675186,
-  "support-channel": 316208160232701955,
+  "plugin-support-channel": 316208160232701955,
+  "mod-support-channel": 1112835241271373966,
+  "proxy-support-channel": 1112837970844721342,
+  "links-channel": 698284788074938388,
   "not-support-channels": [
     316218802155028482,
     316206679014244363


### PR DESCRIPTION
Move channel id of #links into config file, also added multiple support channel ids (for plugin, mod and proxy support) for later (when I want to move Dyno commands into Eduard, I want to make the output different depending on the current support channel)