### PR TITLE
Move ViaBot/Dyno support messages into Eduard

### DIFF
--- a/src/main/java/eu/kennytv/viaeduard/ViaEduardBot.java
+++ b/src/main/java/eu/kennytv/viaeduard/ViaEduardBot.java
@@ -42,7 +42,7 @@ public final class ViaEduardBot {
     private String[] trackedBranches;
     private String privateHelpMessage;
     private String helpMessage;
-    private Set<SupportMessage> supportMessages;
+    private List<SupportMessage> supportMessages;
 
     public static void main(final String[] args) {
         new ViaEduardBot();
@@ -116,7 +116,7 @@ public final class ViaEduardBot {
         nonSupportChannelIds = object.getAsJsonArray("not-support-channels").asList()
                 .stream().map(JsonElement::getAsLong).collect(java.util.stream.Collectors.toSet());
         botChannelId = object.getAsJsonPrimitive("bot-channel").getAsLong();
-        supportMessages = new HashSet<>();
+        supportMessages = new ArrayList<>();
         for (JsonElement element : object.getAsJsonArray("support-messages")) {
             final JsonObject message = element.getAsJsonObject();
             Set<String> commands;
@@ -125,7 +125,7 @@ public final class ViaEduardBot {
             } else if (message.has("command")) {
                 commands = Collections.singleton(message.getAsJsonPrimitive("command").getAsString());
             } else {
-                continue; // bad command
+                throw new IllegalStateException("Invalid support message, missing command");
             }
             final List<SupportMessage.Message> messages = new ArrayList<>();
             if (message.has("messages")) {
@@ -133,14 +133,14 @@ public final class ViaEduardBot {
                 for (Map.Entry<String, JsonElement> entry : messagesElement.entrySet()) {
                     final SupportMessage.Channel channel = SupportMessage.Channel.byName(entry.getKey());
                     if (channel == null) {
-                        continue; // bad command
+                        throw new IllegalStateException("Invalid support message, unknown channel: " + entry.getKey());
                     }
                     messages.add(new SupportMessage.Message(channel, entry.getValue().getAsString()));
                 }
             } else if (message.has("message")) {
                 messages.add(new SupportMessage.Message(null, message.getAsJsonPrimitive("message").getAsString()));
             } else {
-                continue; // bad command
+                throw new IllegalStateException("Invalid support message, missing content");
             }
 
             supportMessages.add(new SupportMessage(commands, messages));
@@ -204,7 +204,7 @@ public final class ViaEduardBot {
         return nonSupportChannelIds;
     }
 
-    public Set<SupportMessage> getSupportMessages() {
+    public List<SupportMessage> getSupportMessages() {
         return supportMessages;
     }
 }

--- a/src/main/java/eu/kennytv/viaeduard/ViaEduardBot.java
+++ b/src/main/java/eu/kennytv/viaeduard/ViaEduardBot.java
@@ -1,26 +1,19 @@
 package eu.kennytv.viaeduard;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
+import com.google.gson.*;
 import eu.kennytv.viaeduard.command.MemoryCommand;
 import eu.kennytv.viaeduard.command.MessageCommand;
 import eu.kennytv.viaeduard.command.ScanDumpsCommand;
 import eu.kennytv.viaeduard.command.base.CommandHandler;
-import eu.kennytv.viaeduard.listener.DumpMessageListener;
-import eu.kennytv.viaeduard.listener.ErrorHelper;
-import eu.kennytv.viaeduard.listener.FileMessageListener;
-import eu.kennytv.viaeduard.listener.HelpMessageListener;
-import eu.kennytv.viaeduard.listener.SlashCommandListener;
+import eu.kennytv.viaeduard.listener.*;
+import eu.kennytv.viaeduard.util.SupportMessage;
 import eu.kennytv.viaeduard.util.Version;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
+
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
@@ -49,6 +42,7 @@ public final class ViaEduardBot {
     private String[] trackedBranches;
     private String privateHelpMessage;
     private String helpMessage;
+    private Set<SupportMessage> supportMessages;
 
     public static void main(final String[] args) {
         new ViaEduardBot();
@@ -71,6 +65,7 @@ public final class ViaEduardBot {
                 .addEventListeners(new DumpMessageListener(this))
                 .addEventListeners(new HelpMessageListener(this))
                 .addEventListeners(new FileMessageListener(this))
+                .addEventListeners(new SupportMessageListener(this))
                 .addEventListeners(new ErrorHelper(this, object.getAsJsonObject("error-helper")));
 
         try {
@@ -121,6 +116,36 @@ public final class ViaEduardBot {
         nonSupportChannelIds = object.getAsJsonArray("not-support-channels").asList()
                 .stream().map(JsonElement::getAsLong).collect(java.util.stream.Collectors.toSet());
         botChannelId = object.getAsJsonPrimitive("bot-channel").getAsLong();
+        supportMessages = new HashSet<>();
+        for (JsonElement element : object.getAsJsonArray("support-messages")) {
+            final JsonObject message = element.getAsJsonObject();
+            Set<String> commands;
+            if (message.has("commands")) {
+                commands = message.getAsJsonArray("commands").asList().stream().map(JsonElement::getAsString).collect(Collectors.toSet());
+            } else if (message.has("command")) {
+                commands = Collections.singleton(message.getAsJsonPrimitive("command").getAsString());
+            } else {
+                continue; // bad command
+            }
+            List<SupportMessage.Message> messages = new ArrayList<>();
+            if (message.has("messages")) {
+                final JsonObject messagesElement = message.getAsJsonObject("messages");
+                int i = 0;
+                for (Map.Entry<String, JsonElement> entry : messagesElement.entrySet()) {
+                    final SupportMessage.Channel channel = SupportMessage.Channel.byName(entry.getKey());
+                    if (channel == null) {
+                        continue; // bad command
+                    }
+                    messages.add(new SupportMessage.Message(channel, entry.getValue().getAsString()));
+                }
+            } else if (message.has("message")) {
+                messages.add(new SupportMessage.Message(null, message.getAsJsonPrimitive("message").getAsString()));
+            } else {
+                continue; // bad command
+            }
+
+            supportMessages.add(new SupportMessage(commands, messages));
+        }
         return object;
     }
 
@@ -178,5 +203,9 @@ public final class ViaEduardBot {
 
     public Set<Long> getNonSupportChannelIds() {
         return nonSupportChannelIds;
+    }
+
+    public Set<SupportMessage> getSupportMessages() {
+        return supportMessages;
     }
 }

--- a/src/main/java/eu/kennytv/viaeduard/ViaEduardBot.java
+++ b/src/main/java/eu/kennytv/viaeduard/ViaEduardBot.java
@@ -127,10 +127,9 @@ public final class ViaEduardBot {
             } else {
                 continue; // bad command
             }
-            List<SupportMessage.Message> messages = new ArrayList<>();
+            final List<SupportMessage.Message> messages = new ArrayList<>();
             if (message.has("messages")) {
                 final JsonObject messagesElement = message.getAsJsonObject("messages");
-                int i = 0;
                 for (Map.Entry<String, JsonElement> entry : messagesElement.entrySet()) {
                     final SupportMessage.Channel channel = SupportMessage.Channel.byName(entry.getKey());
                     if (channel == null) {

--- a/src/main/java/eu/kennytv/viaeduard/listener/SupportMessageListener.java
+++ b/src/main/java/eu/kennytv/viaeduard/listener/SupportMessageListener.java
@@ -1,0 +1,56 @@
+package eu.kennytv.viaeduard.listener;
+
+import eu.kennytv.viaeduard.ViaEduardBot;
+import eu.kennytv.viaeduard.util.SupportMessage;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+
+public final class SupportMessageListener extends ListenerAdapter {
+
+    private final ViaEduardBot bot;
+
+    public SupportMessageListener(final ViaEduardBot bot) {
+        this.bot = bot;
+    }
+
+    @Override
+    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+        if (!event.isFromGuild() || !event.isFromType(ChannelType.TEXT) || event.isWebhookMessage() || event.getAuthor().isBot()) {
+            return;
+        }
+        String line = event.getMessage().getContentRaw();
+        if (line.startsWith("?")) {
+            line = line.substring(1);
+            System.out.println(line);
+            String[] args = line.split(" ");
+
+            for (SupportMessage message : bot.getSupportMessages()) {
+                for (String command : message.getCommands()) {
+                    if (args[0].equalsIgnoreCase(command)) {
+                        SupportMessage.Channel channel = SupportMessage.Channel.byId(bot, event.getChannel().getIdLong());
+                        System.out.println(channel);
+                        if (args.length > 1) {
+                            // Allow to override channel, e.g. ?dump proxy will show the proxy-support dump message in any channel
+                            final SupportMessage.Channel cmdChannel = SupportMessage.Channel.byName(args[1]);
+                            if (cmdChannel != null) channel = cmdChannel; // Ignore argument if invalid
+                        }
+                        // If command isn't executed in one of the support channels, just use the plugin-support message
+                        if (channel == null) {
+                            event.getChannel().sendMessage(message.getMessages().get(0).getMessage()).queue();
+                            return;
+                        }
+                        for (SupportMessage.Message msg : message.getMessages()) {
+                            System.out.println(msg.getChannel() + " " + channel);
+                            if (msg.getChannel() == null || channel == msg.getChannel()) {
+                                event.getChannel().sendMessage(msg.getMessage()).queue();
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/eu/kennytv/viaeduard/listener/SupportMessageListener.java
+++ b/src/main/java/eu/kennytv/viaeduard/listener/SupportMessageListener.java
@@ -23,14 +23,12 @@ public final class SupportMessageListener extends ListenerAdapter {
         String line = event.getMessage().getContentRaw();
         if (line.startsWith("?")) {
             line = line.substring(1);
-            System.out.println(line);
             String[] args = line.split(" ");
 
             for (SupportMessage message : bot.getSupportMessages()) {
                 for (String command : message.getCommands()) {
                     if (args[0].equalsIgnoreCase(command)) {
                         SupportMessage.Channel channel = SupportMessage.Channel.byId(bot, event.getChannel().getIdLong());
-                        System.out.println(channel);
                         if (args.length > 1) {
                             // Allow to override channel, e.g. ?dump proxy will show the proxy-support dump message in any channel
                             final SupportMessage.Channel cmdChannel = SupportMessage.Channel.byName(args[1]);
@@ -42,7 +40,6 @@ public final class SupportMessageListener extends ListenerAdapter {
                             return;
                         }
                         for (SupportMessage.Message msg : message.getMessages()) {
-                            System.out.println(msg.getChannel() + " " + channel);
                             if (msg.getChannel() == null || channel == msg.getChannel()) {
                                 event.getChannel().sendMessage(msg.getMessage()).queue();
                                 return;

--- a/src/main/java/eu/kennytv/viaeduard/listener/SupportMessageListener.java
+++ b/src/main/java/eu/kennytv/viaeduard/listener/SupportMessageListener.java
@@ -21,32 +21,28 @@ public final class SupportMessageListener extends ListenerAdapter {
             return;
         }
         String line = event.getMessage().getContentRaw();
-        if (line.startsWith("?")) {
-            line = line.substring(1);
-            String[] args = line.split(" ");
+        if (!line.startsWith("?")) {
+            // Only listen to support commands
+            return;
+        }
+        line = line.substring(1);
+        final String[] args = line.split(" ");
+        final String command = args[0].toLowerCase();
 
-            for (SupportMessage message : bot.getSupportMessages()) {
-                for (String command : message.getCommands()) {
-                    if (args[0].equalsIgnoreCase(command)) {
-                        SupportMessage.Channel channel = SupportMessage.Channel.byId(bot, event.getChannel().getIdLong());
-                        if (args.length > 1) {
-                            // Allow to override channel, e.g. ?dump proxy will show the proxy-support dump message in any channel
-                            final SupportMessage.Channel cmdChannel = SupportMessage.Channel.byName(args[1]);
-                            if (cmdChannel != null) channel = cmdChannel; // Ignore argument if invalid
-                        }
-                        // If command isn't executed in one of the support channels, just use the plugin-support message
-                        if (channel == null) {
-                            event.getChannel().sendMessage(message.getMessages().get(0).getMessage()).queue();
-                            return;
-                        }
-                        for (SupportMessage.Message msg : message.getMessages()) {
-                            if (msg.getChannel() == null || channel == msg.getChannel()) {
-                                event.getChannel().sendMessage(msg.getMessage()).queue();
-                                return;
-                            }
-                        }
-                    }
+        for (SupportMessage message : bot.getSupportMessages()) {
+            if (message.getCommands().contains(command)) {
+                SupportMessage.Channel channel = SupportMessage.Channel.byId(bot, event.getChannel().getIdLong());
+                if (args.length > 1) {
+                    // Allow to override channel, e.g. ?dump proxy will show the proxy-support dump message in any channel
+                    final SupportMessage.Channel cmdChannel = SupportMessage.Channel.byName(args[1]);
+                    if (cmdChannel != null) channel = cmdChannel; // Ignore argument if invalid
                 }
+                // If command isn't executed in one of the support channels, just use the plugin-support message
+                if (channel == null) {
+                    event.getChannel().sendMessage(message.getMessages().get(0).getMessage()).queue();
+                    return;
+                }
+                message.send(event.getChannel(), channel);
             }
         }
     }

--- a/src/main/java/eu/kennytv/viaeduard/util/SupportMessage.java
+++ b/src/main/java/eu/kennytv/viaeduard/util/SupportMessage.java
@@ -1,6 +1,8 @@
 package eu.kennytv.viaeduard.util;
 
+import com.google.common.base.Preconditions;
 import eu.kennytv.viaeduard.ViaEduardBot;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 
 import java.util.List;
 import java.util.Set;
@@ -11,8 +13,20 @@ public class SupportMessage {
     private final List<Message> messages;
 
     public SupportMessage(final Set<String> commands, final List<Message> messages) {
+        Preconditions.checkArgument(!commands.isEmpty(), "commands must not be empty");
+        Preconditions.checkArgument(!messages.isEmpty(), "messages must not be empty");
+
         this.commands = commands;
         this.messages = messages;
+    }
+
+    public void send(final MessageChannelUnion messageChannel, final Channel channel) {
+        for (SupportMessage.Message msg : getMessages()) {
+            if (msg.getChannel() == null || channel == msg.getChannel()) {
+                messageChannel.sendMessage(msg.getMessage()).queue();
+                return;
+            }
+        }
     }
 
     public Set<String> getCommands() {

--- a/src/main/java/eu/kennytv/viaeduard/util/SupportMessage.java
+++ b/src/main/java/eu/kennytv/viaeduard/util/SupportMessage.java
@@ -1,0 +1,82 @@
+package eu.kennytv.viaeduard.util;
+
+import eu.kennytv.viaeduard.ViaEduardBot;
+
+import java.util.List;
+import java.util.Set;
+
+public class SupportMessage {
+
+    private final Set<String> commands;
+    private final List<Message> messages;
+
+    public SupportMessage(final Set<String> commands, final List<Message> messages) {
+        this.commands = commands;
+        this.messages = messages;
+    }
+
+    public Set<String> getCommands() {
+        return commands;
+    }
+
+    public List<Message> getMessages() {
+        return messages;
+    }
+
+    public static class Message {
+
+        private final Channel channel;
+        private final String message;
+
+        public Message(final Channel channel, final String message) {
+            this.channel = channel;
+            this.message = message;
+        }
+
+        public Channel getChannel() {
+            return channel;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    public enum Channel {
+        PLUGIN_SUPPORT("plugin"),
+        MOD_SUPPORT("mod"),
+        PROXY_SUPPORT("proxy");
+
+        private final String name;
+
+        Channel(final String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public static Channel byName(final String name) {
+            for (Channel channel : values()) {
+                if (channel.getName().equals(name)) {
+                    return channel;
+                }
+            }
+            return null;
+        }
+
+        public static Channel byId(final ViaEduardBot bot, final long id) {
+            if (id == bot.getPluginSupportChannelId()) {
+                return PLUGIN_SUPPORT;
+            } else if (id == bot.getModSupportChannelId()) {
+                return MOD_SUPPORT;
+            } else if (id == bot.getProxySupportChannelId()) {
+                return PROXY_SUPPORT;
+            } else {
+                return null;
+            }
+        }
+    }
+
+}

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -52,8 +52,8 @@
       "message": "Please download the latest ViaVersion plugins from the <#698284788074938388> channel. Remember to delete your old `.jar` files before downloading the new ones."
     },
     {
-      "commands": ["bungeecord", "bungee"],
-      "message": "Please update your proxy to the latest version to support 1.8 - latest release clients\n**BungeeCord** - https://ci.md-5.net/job/BungeeCord/\n**Waterfall** - https://papermc.io/downloads#Waterfall\n**Velocity** - https://papermc.io/downloads#Velocity"
+      "commands": ["bungeecord", "bungee", "proxy", "velocity"],
+      "message": "Please update your proxy to the latest version to support 1.8 - latest release clients\n**BungeeCord** - https://ci.md-5.net/job/BungeeCord\n**Velocity** - https://papermc.io/downloads#Velocity"
     },
     {
       "command": "packets",
@@ -61,20 +61,20 @@
     },
     {
       "command": "tab",
-      "message": "If your players are getting kicked for spam, it's due to 1.13 tab-complete executing too fast.\n\nWays to solve this:\n- Update ViaVersion from <#698284788074938388> and edit `1_13-tab-complete-delay: 5` in the config. 5 is suggested to avoid kicking.\n- Disable tab-complete for 1.13+ using `disable-1_13-auto-complete: true` in the config.\n- If you use Paper 1.12+ you can change the spam limit in paper.yml."
+      "message": "If your players are getting kicked for spam, it's due to 1.13+ tab-complete executing too fast.\n\nWays to solve this:\n- Update ViaVersion from <#698284788074938388> and edit `1_13-tab-complete-delay: 5` in the config. 5 is suggested to avoid kicking.\n- Disable tab-complete for 1.13+ using `disable-1_13-auto-complete: true` in the config.\n- If you use Paper 1.12+ you can change the spam limit in paper.yml."
     },
     {
       "commands": ["connections", "blockconnections"],
-      "message": "If you want ViaVersion to calculate how to connect blocks for 1.13+ make sure you set `serverside-blockconnections: true` in the ViaVersion config. This was previously disabled by default as it uses slightly more CPU per user."
+      "message": "If you want ViaVersion to calculate how to connect blocks for 1.13+ make sure you set `serverside-blockconnections: true` in the ViaVersion config. This was previously disabled by default as it uses slightly more CPU per player."
     },
     {
       "commands": ["blockprotocols", "blockversions", "block"],
-      "message": "You can use https://via.krusic22.com/ to generate the list for `block-protocols` in the ViaVersion config, this will allow you to allow / deny specific versions.\nYou can also use `block-versions` to specify blocked versions by using its minecraft name (\"1.17\") and operands like `< >`. For example  `\"<1.17\"` will only allow 1.17.x and above to join"
+      "message": "You can use https://via.krusic22.com/ to generate the list for `block-protocols` in the ViaVersion config, this will allow you to allow / deny specific versions.\nYou can also use `block-versions` to specify blocked versions by using its minecraft name (\"1.17\") and operands like `< >` (you can also use https://viaversion.com/setup to generate the list). For example  `\"<1.17\"` will only allow 1.17.x and above to join"
     },
     {
-      "command": "where",
+      "commands": ["where", "stack"],
       "messages": {
-        "plugin": "Please only install Via* plugins on either Bungee/Velocity **OR** backend servers (e.g. Spigot / Paper / Sponge). We recommend **backend servers** because it will give ViaVersion more information and a better experience.",
+        "plugin": "Please only install Via* plugins on either Bungee/Velocity **OR** backend servers *(e.g. Spigot / Paper / Sponge)*. We recommend **backend servers** because it will give ViaVersion more information and a better experience.",
         "mod": "ViaFabricPlus can be only installed on the client side, ViaFabric can be installed on both client and server side.",
         "proxy": "ViaProxy is a standalone software and doesn't have to be installed on a server or as a mod."
       }
@@ -92,13 +92,13 @@
       "messages": {
         "plugin": "Please run `/viaversion dump` in-game or in your console and copy the link into this channel, it gives us useful information about your server.",
         "mod": "Please run `/viafabricplus dump` in-game and copy the link into this channel, it gives us useful information about your client.",
-        "proxy": "Please go to `Advanced` and run `Create ViaVersion dump` and copy the link into this channel."
+        "proxy": "Please go to `Advanced` and run `Create ViaVersion dump` and provide us the link."
       }
     },
     {
       "commands": ["error", "spam", "suppress"],
       "messages": {
-        "plugin": "To fix console spam, use `suppress-conversion-warnings: true` and `suppress-metadata-errors: true` in the ViaVersion config.yml. The errors will still happen but you won't be spammed with them and the issues will be ignored.",
+        "plugin": "To fix console spam, use `suppress-conversion-warnings: true` and `suppress-metadata-errors: true` in the ViaVersion `config.yml`. The errors will still happen but you won't be spammed with them and the issues will be ignored.",
         "mod": "To fix log spam, use `suppress-conversion-warnings: true` and `suppress-metadata-errors: true` in the viaversion.yml (located in `config/viafabricplus/ViaLoader`). The errors will still happen but you won't be spammed with them and the issues will be ignored.",
         "proxy": "To fix log spam, use `suppress-conversion-warnings: true` and `suppress-metadata-errors: true` in the viaversion.yml (located in `ViaLoader`). The errors will still happen but you won't be spammed with them and the issues will be ignored."
       }
@@ -108,8 +108,8 @@
       "message": "Please use https://mclo.gs for pasting long text / code / server/client logs."
     },
     {
-      "commands": ["plugins", "pl"],
-      "message": "If you want newer versions, e.g. 1.15.2 on 1.15 server, download just ViaVersion.\nIf you want older versions, e.g. 1.14.4 on 1.15 server, download ViaVersion and ViaBackwards.\nIf you want 1.7 / 1.8 versions, download ViaVersion, ViaBackwards and ViaRewind\n\nStill confused? Try this tool - https://jo0001.github.io/ViaSetup/"
+      "commands": ["plugins", "pl", "setup"],
+      "message": "If you want newer versions, e.g. 1.15.2 on 1.15 server, download just ViaVersion.\nIf you want older versions, e.g. 1.14.4 on 1.15 server, download ViaVersion and ViaBackwards.\nIf you want 1.7 / 1.8 versions, download ViaVersion, ViaBackwards and ViaRewind\n\nStill confused? Try this tool - https://viaversion.com/setup"
     },
     {
       "command": "api",
@@ -120,19 +120,11 @@
       }
     },
     {
-      "command": "stack",
-      "message": "Please only install Via* plugins on either Bungee/Velocity **OR** backend servers (e.g. Spigot / Paper / Sponge). We recommend **backend servers** because it will give ViaVersion more information and a better experience."
-    },
-    {
-      "command": "proxy",
-      "message": "Please update your proxy to the latest version to support 1.8 - latest release clients\n**BungeeCord** - https://ci.md-5.net/job/BungeeCord/\n**Waterfall** - https://papermc.io/downloads#Waterfall\n**Velocity** - https://papermc.io/downloads#Velocity"
-    },
-    {
-      "command": "mapping",
+      "commands": ["mapping", "mappings"],
       "message": "This is an example of how the mapping works in Via:\nhttps://raw.githubusercontent.com/Jo0001/ViaRemapping/master/1.20-1.19.png"
     },
     {
-      "command": "platforms",
+      "commands": ["platforms", "platform"],
       "message": "Here are the officially supported platforms:\nPaper and Spigot as a **plugin**\nSponge (1.12) as a **sponge plugin**\nWaterfall and Bungeecord as a **plugin** (Run the latest version of the proxy!)\nVelocity as a **plugin** (Run the latest version of the proxy!)\nFabric 1.8/1.14+ as a mod. Requires **ViaFabric (Plus)** and **Fabric API** for your game version.\nStandalone as **proxy** with ViaaaS & ViaProxy.\n\nFor a overview checkout https://jo0001.github.io/ViaSetup/ViaSuite\n\n\nSide note: As a network owner, running Via on the backend servers is recommended even if you have a ViaVersion compatible proxy"
     },
     {
@@ -141,15 +133,11 @@
     },
     {
       "command": "cooldown",
-      "message": "Specify how 1.8.x clients should see the cooldown indicator\nIn the Via**Rewind** config.yml set `cooldown-indicator: `  to\n `TITLE`,` ACTION_BAR`, `BOSS_BAR` or `DISABLED`\n*Note: This will only hide the cooldown, not disable it!*"
-    },
-    {
-      "command": "setup",
-      "message": "If you want newer versions, e.g. 1.15.2 on 1.15 server, download just ViaVersion.\nIf you want older versions, e.g. 1.14.4 on 1.15 server, download ViaVersion and ViaBackwards.\nIf you want 1.7 / 1.8 versions, download ViaVersion, ViaBackwards and ViaRewind\n\nStill confused? Try this tool - https://viaversion.com/setup"
+      "message": "Specify how 1.8.x clients should see the cooldown indicator\nIn the Via**Rewind** `config.yml` set `cooldown-indicator: ` to\n `TITLE`,`ACTION_BAR`,`BOSS_BAR` or `DISABLED`\n*Note: This will only hide the cooldown, not disable it!*"
     },
     {
       "command": "api-update",
-      "message": "Information about how to use the Via-API in the latest release can be found here: https://gist.github.com/KennyTV/3778685985ddc45bd99e003191ff02eb"
+      "message": "Information about how to use the Via API in the latest release can be found here: https://gist.github.com/KennyTV/3778685985ddc45bd99e003191ff02eb"
     },
     {
       "command": "error",

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -57,7 +57,7 @@
     },
     {
       "command": "packets",
-      "message": "If you were kicked for \"You are sending too many packets!\", Change `max-pps` in the ViaVersion `config.yml` to either a higher number or -1 to disable it. Use `/viaversion pps` in-game to view how many packets players are sending."
+      "message": "If you were kicked for \"You are sending too many packets!\", change `max-pps` in the ViaVersion `config.yml` to either a higher number or -1 to disable it. Use `/viaversion pps` in-game to view how many packets players are sending."
     },
     {
       "command": "tab",
@@ -69,7 +69,7 @@
     },
     {
       "commands": ["blockprotocols", "blockversions", "block"],
-      "message": "You can use https://via.krusic22.com/ to generate the list for `block-protocols` in the ViaVersion config, this will allow you to allow / deny specific versions.\nYou can also use `block-versions` to specify blocked versions by using it's Minecraft name (\"1.17\") and operands like `< >`. For example `\"<1.17\"` will only allow 1.17.x and above to join.\n*(You can also use https://viaversion.com/setup to generate the list)*"
+      "message": "You can use https://via.krusic22.com/ to generate the list for `block-protocols` in the ViaVersion config, this will allow you to allow / deny specific versions.\nYou can also use `block-versions` to specify blocked versions by using its minecraft name (\"1.17\") and operands like `< >`. For example `\"<1.17\"` will only allow 1.17.x and above to join.\n*(You can also use https://viaversion.com/setup to generate the list)*"
     },
     {
       "commands": ["where", "stack"],
@@ -153,15 +153,15 @@
     },
     {
       "command": "btlp",
-      "message": "There is a current issue with BungeeTabListPlus and the latest Minecraft update, We suggest following their discord for updates."
+      "message": "There is a current issue with BungeeTabListPlus and the latest Minecraft update, we suggest following their discord for updates."
     },
     {
       "command": "reload",
-      "message": "**Do not use the `/reload` command**. It will cause issues with your server and it's plugins. For more information, see https://madelinemiller.dev/blog/problem-with-reload/\n*Note: You can safely use `/minecraft:reload` to reload datapacks.*"
+      "message": "**Do not use the `/reload` command**. It will cause issues with your server and its plugins. For more information, see https://madelinemiller.dev/blog/problem-with-reload/\n*Note: You can safely use `/minecraft:reload` to reload datapacks.*"
     },
     {
       "command": "height",
-      "message": "Every player on 1.7.x - 1.16.5 can still play on a 1.18+ server but **the new world height is not supported** *(players are stuck below y=0 & only see void)*\n\n*To avoid/revert this, Use a datapack or downgrade back to 1.17.1 or only allow 1.17+ players, see https://gist.github.com/Jo0001/4fe96cf5a78c8a00560ea985f3b9eb22 for more information.*"
+      "message": "Every player on 1.7.x - 1.16.5 can still play on a 1.18+ server but **the new world height is not supported** *(players are stuck below y=0 & only see void)*\n\n*To avoid/revert this, use a datapack or downgrade back to 1.17.1 or only allow 1.17+ players, see https://gist.github.com/Jo0001/4fe96cf5a78c8a00560ea985f3b9eb22 for more information.*"
     }
   ]
 }

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -37,13 +37,13 @@
       "match-text": ["Source 0: com.viaversion.viaversion.protocols.base.BaseProtocol1_7$$Lambda$3268/0x000000080154a200"],
       "error-message": "This error is most likely caused by your proxy software being out of date, or incompatibility with another plugin like limbo, or custom client.",
       "confidence": 80,
-      "from": ["text", "file","image"]
+      "from": ["text", "file", "image"]
     },
     "BlockedProtocols": {
       "match-text": ["You are using an unsupported Minecraft version!"],
       "error-message": "'You are using an unsupported Minecraft version!' is the default message for the blocked-versions/protocols setting. Please check your ViaVersion config and make sure you have the correct version set.",
       "confidence": 80,
-      "from": ["text", "file","image"]
+      "from": ["text", "file", "image"]
     }
   },
   "support-messages": [
@@ -57,11 +57,11 @@
     },
     {
       "command": "packets",
-      "message": "If you were kicked for \"You are sending too many packets!\" change `max-pps` in the ViaVersion config.yml to either a higher number or -1 to disable it. Use `/viaversion pps` in-game to view how many packets players are sending."
+      "message": "If you were kicked for \"You are sending too many packets!\", Change `max-pps` in the ViaVersion `config.yml` to either a higher number or -1 to disable it. Use `/viaversion pps` in-game to view how many packets players are sending."
     },
     {
       "command": "tab",
-      "message": "If your players are getting kicked for spam, it's due to 1.13+ tab-complete executing too fast.\n\nWays to solve this:\n- Update ViaVersion from <#698284788074938388> and edit `1_13-tab-complete-delay: 5` in the config. 5 is suggested to avoid kicking.\n- Disable tab-complete for 1.13+ using `disable-1_13-auto-complete: true` in the config.\n- If you use Paper 1.12+ you can change the spam limit in paper.yml."
+      "message": "If your players are getting kicked for spam, it's due to 1.13+'s tab-complete executing too fast.\n\nWays to solve this:\n- Update ViaVersion from <#698284788074938388> and edit `1_13-tab-complete-delay: 5` in the config. 5 is suggested to avoid kicking.\n- Disable tab-complete for 1.13+ using `disable-1_13-auto-complete: true` in the config.\n- If you use Paper 1.17.1+ then you can change the spam limit in paper.yml *(or in config/paper-global.yml if using 1.19+)* instead."
     },
     {
       "commands": ["connections", "blockconnections"],
@@ -69,7 +69,7 @@
     },
     {
       "commands": ["blockprotocols", "blockversions", "block"],
-      "message": "You can use https://via.krusic22.com/ to generate the list for `block-protocols` in the ViaVersion config, this will allow you to allow / deny specific versions.\nYou can also use `block-versions` to specify blocked versions by using its minecraft name (\"1.17\") and operands like `< >` (you can also use https://viaversion.com/setup to generate the list). For example  `\"<1.17\"` will only allow 1.17.x and above to join"
+      "message": "You can use https://via.krusic22.com/ to generate the list for `block-protocols` in the ViaVersion config, this will allow you to allow / deny specific versions.\nYou can also use `block-versions` to specify blocked versions by using it's Minecraft name (\"1.17\") and operands like `< >`. For example `\"<1.17\"` will only allow 1.17.x and above to join.\n*(You can also use https://viaversion.com/setup to generate the list)*"
     },
     {
       "commands": ["where", "stack"],
@@ -82,8 +82,8 @@
     {
       "command": "more",
       "messages": {
-        "plugin": "Please provide more information:\n- Enable `debug=true` in server.properties and recreate the issue.\n- Provide `/viaversion dump` link, this will allow us to work out incompatibilities\n- Ensure you've said the **client-version** the issue happens with.",
-        "mod": "Please provide more information:\n- Provide `/viafabricplus dump` link, this will allow us to work out incompatibilities\n- Provide your `latest.log` file\n- Ensure you've said the **target-version** the issue happens with.",
+        "plugin": "Please provide more information:\n- Enable `debug=true` in server.properties and recreate the issue.\n- Provide `/viaversion dump` link, this will allow us to work out incompatibilities.\n- Ensure you've said the **client-version** the issue happens with.",
+        "mod": "Please provide more information:\n- Provide `/viafabricplus dump` link, this will allow us to work out incompatibilities.\n- Provide your `latest.log` file.\n- Ensure you've said the **target-version** the issue happens with.",
         "proxy": "Please provide more information:\n- Go to `Advanced` and run `Create ViaVersion dump` and provide us the link.\n- Go to `Advanced` and run `Upload latest log file` and provide us the link.\n- Ensure you've said the **Server Version** the issue happens with."
       }
     },
@@ -105,7 +105,7 @@
     },
     {
       "command": "paste",
-      "message": "Please use https://mclo.gs for pasting long text / code / server/client logs."
+      "message": "Please use https://mclo.gs/ for pasting long text / code / server/client logs."
     },
     {
       "commands": ["plugins", "pl", "setup"],
@@ -120,16 +120,24 @@
       }
     },
     {
+      "command": "stack",
+      "message": "Please only install Via* plugins on either Bungee/Velocity **OR** backend servers *(e.g. Spigot / Paper / Sponge)*. We recommend **backend servers** because it will give ViaVersion more information and a better experience."
+    },
+    {
+      "command": "proxy",
+      "message": "Please update your proxy to the latest version to support 1.8 - latest release clients.\n**BungeeCord** - https://ci.md-5.net/job/BungeeCord\n**Velocity** - https://papermc.io/downloads#Velocity"
+    },
+    {
       "commands": ["mapping", "mappings"],
       "message": "This is an example of how the mapping works in Via:\nhttps://raw.githubusercontent.com/Jo0001/ViaRemapping/master/1.20-1.19.png"
     },
     {
       "commands": ["platforms", "platform"],
-      "message": "Here are the officially supported platforms:\nPaper and Spigot as a **plugin**\nSponge (1.12) as a **sponge plugin**\nWaterfall and Bungeecord as a **plugin** (Run the latest version of the proxy!)\nVelocity as a **plugin** (Run the latest version of the proxy!)\nFabric 1.8/1.14+ as a mod. Requires **ViaFabric (Plus)** and **Fabric API** for your game version.\nStandalone as **proxy** with ViaaaS & ViaProxy.\n\nFor a overview checkout https://jo0001.github.io/ViaSetup/ViaSuite\n\n\nSide note: As a network owner, running Via on the backend servers is recommended even if you have a ViaVersion compatible proxy"
+      "message": "Here are the officially supported platforms:\nPaper and Spigot as a **plugin**\nSponge as a **sponge plugin**\nBungeecord as a **plugin** *(Run the latest version of the proxy!)*\nVelocity as a **plugin** *(Run the latest version of the proxy!)*\nFabric 1.8/1.14+ as a mod. Requires **ViaFabric (Plus)** and **Fabric API** for your game version.\nStandalone as **proxy** with ViaaaS & ViaProxy.\n\nFor a overview checkout - https://viaversion.com/suite\n\n\n*Side note: As a network owner, running Via on the backend servers is recommended even if you have a ViaVersion compatible proxy.*"
     },
     {
       "command": "tps",
-      "message": "**ViaVersion is causing TPS lag in timings?**\n\nViaVersion for versions 1.9 and above on 1.8 has to simulate player ticking for them to eat, draw bows etc. This means our plugin looks like it's causing lag but it's actually calling Minecraft server methods. You can turn of `nms-player-ticking` in the `config.yml` to use an alternate method that won't touch timings but may cause issues with anti-cheat."
+      "message": "**ViaVersion is causing TPS lag in timings?**\n\nViaVersion for versions 1.9 and above on 1.8 has to simulate player ticking for them to eat, draw bows, etc. This means our plugin looks like it's causing lag but it's actually calling Minecraft server methods. You can turn off `nms-player-ticking` in the ViaVersion `config.yml` to use an alternate method that won't touch timings but may cause issues with anti-cheat."
     },
     {
       "command": "cooldown",
@@ -141,19 +149,19 @@
     },
     {
       "command": "error",
-      "message": "**That issue is not from Via, it's from the plugin shown in the stack trace. Try the latest version of that plugin or contact the author of it and tell them to update the Via API usage**"
+      "message": "**That issue is not from Via, it's from the plugin shown in the stack trace. Try the latest version of that plugin or contact the author of it and tell them to update the Via API usage.**"
     },
     {
       "command": "btlp",
-      "message": "There is a current issue with BungeeTabListPlus and the latest Minecraft update, we suggest following their discord for updates."
+      "message": "There is a current issue with BungeeTabListPlus and the latest Minecraft update, We suggest following their discord for updates."
     },
     {
       "command": "reload",
-      "message": "**Do not use the `/reload` command**. It will cause issues with your server and its plugins. For more information, see https://madelinemiller.dev/blog/problem-with-reload/\n*Note: You can safely use `/minecraft:reload` to reload datapacks*"
+      "message": "**Do not use the `/reload` command**. It will cause issues with your server and it's plugins. For more information, see https://madelinemiller.dev/blog/problem-with-reload/\n*Note: You can safely use `/minecraft:reload` to reload datapacks.*"
     },
     {
       "command": "height",
-      "message": "Every player on 1.7.x - 1.16.5 can still play on a  1.18+ server but  **the new world height is not supported**  (players are stuck below y=0 & only see void)\n\n*To avoid/revert this use a datapack or downgrade back to 1.17.1 or only allow 1.17+ players, see https://gist.github.com/Jo0001/4fe96cf5a78c8a00560ea985f3b9eb22 for more information*"
+      "message": "Every player on 1.7.x - 1.16.5 can still play on a 1.18+ server but **the new world height is not supported** *(players are stuck below y=0 & only see void)*\n\n*To avoid/revert this, Use a datapack or downgrade back to 1.17.1 or only allow 1.17+ players, see https://gist.github.com/Jo0001/4fe96cf5a78c8a00560ea985f3b9eb22 for more information.*"
     }
   ]
 }

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -45,5 +45,127 @@
       "confidence": 80,
       "from": ["text", "file","image"]
     }
-  }
+  },
+  "support-messages": [
+    {
+      "commands": ["download", "dl"],
+      "message": "Please download the latest ViaVersion plugins from the <#698284788074938388> channel. Remember to delete your old `.jar` files before downloading the new ones."
+    },
+    {
+      "commands": ["bungeecord", "bungee"],
+      "message": "Please update your proxy to the latest version to support 1.8 - latest release clients\n**BungeeCord** - https://ci.md-5.net/job/BungeeCord/\n**Waterfall** - https://papermc.io/downloads#Waterfall\n**Velocity** - https://papermc.io/downloads#Velocity"
+    },
+    {
+      "command": "packets",
+      "message": "If you were kicked for \"You are sending too many packets!\" change `max-pps` in the ViaVersion config.yml to either a higher number or -1 to disable it. Use `/viaversion pps` in-game to view how many packets players are sending."
+    },
+    {
+      "command": "tab",
+      "message": "If your players are getting kicked for spam, it's due to 1.13 tab-complete executing too fast.\n\nWays to solve this:\n- Update ViaVersion from <#698284788074938388> and edit `1_13-tab-complete-delay: 5` in the config. 5 is suggested to avoid kicking.\n- Disable tab-complete for 1.13+ using `disable-1_13-auto-complete: true` in the config.\n- If you use Paper 1.12+ you can change the spam limit in paper.yml."
+    },
+    {
+      "commands": ["connections", "blockconnections"],
+      "message": "If you want ViaVersion to calculate how to connect blocks for 1.13+ make sure you set `serverside-blockconnections: true` in the ViaVersion config. This was previously disabled by default as it uses slightly more CPU per user."
+    },
+    {
+      "commands": ["blockprotocols", "blockversions", "block"],
+      "message": "You can use https://via.krusic22.com/ to generate the list for `block-protocols` in the ViaVersion config, this will allow you to allow / deny specific versions.\nYou can also use `block-versions` to specify blocked versions by using its minecraft name (\"1.17\") and operands like `< >`. For example  `\"<1.17\"` will only allow 1.17.x and above to join"
+    },
+    {
+      "command": "where",
+      "messages": {
+        "plugin": "Please only install Via* plugins on either Bungee/Velocity **OR** backend servers (e.g. Spigot / Paper / Sponge). We recommend **backend servers** because it will give ViaVersion more information and a better experience.",
+        "mod": "ViaFabricPlus can be only installed on the client side, ViaFabric can be installed on both client and server side.",
+        "proxy": "ViaProxy is a standalone software and doesn't have to be installed on a server or as a mod."
+      }
+    },
+    {
+      "command": "more",
+      "messages": {
+        "plugin": "Please provide more information:\n- Enable `debug=true` in server.properties and recreate the issue.\n- Provide `/viaversion dump` link, this will allow us to work out incompatibilities\n- Ensure you've said the **client-version** the issue happens with.",
+        "mod": "Please provide more information:\n- Provide `/viafabricplus dump` link, this will allow us to work out incompatibilities\n- Provide your `latest.log` file\n- Ensure you've said the **target-version** the issue happens with.",
+        "proxy": "Please provide more information:\n- Go to `Advanced` and run `Create ViaVersion dump` and provide us the link.\n- Go to `Advanced` and run `Upload latest log file` and provide us the link.\n- Ensure you've said the **Server Version** the issue happens with."
+      }
+    },
+    {
+      "commands": ["viadump", "dump"],
+      "messages": {
+        "plugin": "Please run `/viaversion dump` in-game or in your console and copy the link into this channel, it gives us useful information about your server.",
+        "mod": "Please run `/viafabricplus dump` in-game and copy the link into this channel, it gives us useful information about your client.",
+        "proxy": "Please go to `Advanced` and run `Create ViaVersion dump` and copy the link into this channel."
+      }
+    },
+    {
+      "commands": ["error", "spam", "suppress"],
+      "messages": {
+        "plugin": "To fix console spam, use `suppress-conversion-warnings: true` and `suppress-metadata-errors: true` in the ViaVersion config.yml. The errors will still happen but you won't be spammed with them and the issues will be ignored.",
+        "mod": "To fix log spam, use `suppress-conversion-warnings: true` and `suppress-metadata-errors: true` in the viaversion.yml (located in `config/viafabricplus/ViaLoader`). The errors will still happen but you won't be spammed with them and the issues will be ignored.",
+        "proxy": "To fix log spam, use `suppress-conversion-warnings: true` and `suppress-metadata-errors: true` in the viaversion.yml (located in `ViaLoader`). The errors will still happen but you won't be spammed with them and the issues will be ignored."
+      }
+    },
+    {
+      "command": "paste",
+      "message": "Please use https://mclo.gs for pasting long text / code / server/client logs."
+    },
+    {
+      "commands": ["plugins", "pl"],
+      "message": "If you want newer versions, e.g. 1.15.2 on 1.15 server, download just ViaVersion.\nIf you want older versions, e.g. 1.14.4 on 1.15 server, download ViaVersion and ViaBackwards.\nIf you want 1.7 / 1.8 versions, download ViaVersion, ViaBackwards and ViaRewind\n\nStill confused? Try this tool - https://jo0001.github.io/ViaSetup/"
+    },
+    {
+      "command": "api",
+      "messages": {
+        "plugin": "You can find documentation on how to use our API over at https://docs.viaversion.com/display/VIAVERSION/Basic+API+usage",
+        "mod": "You can find documentation and contributing guidelines for ViaFabricPlus over at https://github.com/ViaVersion/ViaFabricPlus/tree/main/docs",
+        "proxy": "You can find documentation on how to create ViaProxy plugins over at https://github.com/ViaVersion/ViaFabricPlus/tree/main/docs"
+      }
+    },
+    {
+      "command": "stack",
+      "message": "Please only install Via* plugins on either Bungee/Velocity **OR** backend servers (e.g. Spigot / Paper / Sponge). We recommend **backend servers** because it will give ViaVersion more information and a better experience."
+    },
+    {
+      "command": "proxy",
+      "message": "Please update your proxy to the latest version to support 1.8 - latest release clients\n**BungeeCord** - https://ci.md-5.net/job/BungeeCord/\n**Waterfall** - https://papermc.io/downloads#Waterfall\n**Velocity** - https://papermc.io/downloads#Velocity"
+    },
+    {
+      "command": "mapping",
+      "message": "This is an example of how the mapping works in Via:\nhttps://raw.githubusercontent.com/Jo0001/ViaRemapping/master/1.20-1.19.png"
+    },
+    {
+      "command": "platforms",
+      "message": "Here are the officially supported platforms:\nPaper and Spigot as a **plugin**\nSponge (1.12) as a **sponge plugin**\nWaterfall and Bungeecord as a **plugin** (Run the latest version of the proxy!)\nVelocity as a **plugin** (Run the latest version of the proxy!)\nFabric 1.8/1.14+ as a mod. Requires **ViaFabric (Plus)** and **Fabric API** for your game version.\nStandalone as **proxy** with ViaaaS & ViaProxy.\n\nFor a overview checkout https://jo0001.github.io/ViaSetup/ViaSuite\n\n\nSide note: As a network owner, running Via on the backend servers is recommended even if you have a ViaVersion compatible proxy"
+    },
+    {
+      "command": "tps",
+      "message": "**ViaVersion is causing TPS lag in timings?**\n\nViaVersion for versions 1.9 and above on 1.8 has to simulate player ticking for them to eat, draw bows etc. This means our plugin looks like it's causing lag but it's actually calling Minecraft server methods. You can turn of `nms-player-ticking` in the `config.yml` to use an alternate method that won't touch timings but may cause issues with anti-cheat."
+    },
+    {
+      "command": "cooldown",
+      "message": "Specify how 1.8.x clients should see the cooldown indicator\nIn the Via**Rewind** config.yml set `cooldown-indicator: `  to\n `TITLE`,` ACTION_BAR`, `BOSS_BAR` or `DISABLED`\n*Note: This will only hide the cooldown, not disable it!*"
+    },
+    {
+      "command": "setup",
+      "message": "If you want newer versions, e.g. 1.15.2 on 1.15 server, download just ViaVersion.\nIf you want older versions, e.g. 1.14.4 on 1.15 server, download ViaVersion and ViaBackwards.\nIf you want 1.7 / 1.8 versions, download ViaVersion, ViaBackwards and ViaRewind\n\nStill confused? Try this tool - https://viaversion.com/setup"
+    },
+    {
+      "command": "api-update",
+      "message": "Information about how to use the Via-API in the latest release can be found here: https://gist.github.com/KennyTV/3778685985ddc45bd99e003191ff02eb"
+    },
+    {
+      "command": "error",
+      "message": "**That issue is not from Via, it's from the plugin shown in the stack trace. Try the latest version of that plugin or contact the author of it and tell them to update the Via API usage**"
+    },
+    {
+      "command": "btlp",
+      "message": "There is a current issue with BungeeTabListPlus and the latest Minecraft update, we suggest following their discord for updates."
+    },
+    {
+      "command": "reload",
+      "message": "**Do not use the `/reload` command**. It will cause issues with your server and its plugins. For more information, see https://madelinemiller.dev/blog/problem-with-reload/\n*Note: You can safely use `/minecraft:reload` to reload datapacks*"
+    },
+    {
+      "command": "height",
+      "message": "Every player on 1.7.x - 1.16.5 can still play on a  1.18+ server but  **the new world height is not supported**  (players are stuck below y=0 & only see void)\n\n*To avoid/revert this use a datapack or downgrade back to 1.17.1 or only allow 1.17+ players, see https://gist.github.com/Jo0001/4fe96cf5a78c8a00560ea985f3b9eb22 for more information*"
+    }
+  ]
 }


### PR DESCRIPTION
Initial commit adding support messages into our own bot, the new system allows us to change the output message depending on the channel, it's also possible to force specific output message, e.g. "?dump proxy" will always send the dump message you would want in the proxy-support-channel (aliases are plugin, mod and proxy). The new system also allows aliases like ?blockprotocols -> ?block