### PR TITLE
Basic Athena Implementation

### DIFF
--- a/src/main/java/com/viaversion/eduard/ViaEduardBot.java
+++ b/src/main/java/com/viaversion/eduard/ViaEduardBot.java
@@ -14,6 +14,7 @@ import com.viaversion.eduard.listener.DumpMessageListener;
 import com.viaversion.eduard.listener.ErrorHelper;
 import com.viaversion.eduard.listener.FileMessageListener;
 import com.viaversion.eduard.listener.HelpMessageListener;
+import com.viaversion.eduard.listener.LogListener;
 import com.viaversion.eduard.listener.SlashCommandListener;
 import com.viaversion.eduard.listener.SupportMessageListener;
 import com.viaversion.eduard.util.SupportMessage;
@@ -82,7 +83,8 @@ public final class ViaEduardBot {
             .addEventListeners(new HelpMessageListener(this))
             .addEventListeners(new FileMessageListener(this))
             .addEventListeners(new SupportMessageListener(this))
-            .addEventListeners(new ErrorHelper(this, object.getAsJsonObject("error-helper")));
+            .addEventListeners(new ErrorHelper(this, object.getAsJsonObject("error-helper")))
+            .addEventListeners(new LogListener(this));
 
         try {
             jda = builder.build().awaitReady();

--- a/src/main/java/com/viaversion/eduard/listener/LogListener.java
+++ b/src/main/java/com/viaversion/eduard/listener/LogListener.java
@@ -1,31 +1,28 @@
 package com.viaversion.eduard.listener;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.viaversion.eduard.ViaEduardBot;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
-import org.jetbrains.annotations.NotNull;
-
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.viaversion.eduard.ViaEduardBot;
-
 import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
 
 public final class LogListener extends ListenerAdapter {
-    String[] blacklist = new String[]{"https://ci.viaversion.com", "https://dump.viaversion.com", "https://github.com", "https://modrinth.com", "https://hangar.papermc.io", "https://viaversion.com"};
-    String[] allowedChannels = new String[]{"plugin-support", "bot-test"};
-    Pattern urlPattern = Pattern.compile("\\(?\\bhttps://[-A-Za-z0-9+&@#/%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%=~_()|]");//https://blog.codinghorror.com/the-problem-with-urls/
+    private static final List<String> BLACKLIST = List.of("https://ci.viaversion.com", "https://dump.viaversion.com", "https://github.com", "https://modrinth.com", "https://hangar.papermc.io", "https://viaversion.com");
+    private static final Pattern URL_PATTERN = Pattern.compile("\\(?\\bhttps://[-A-Za-z0-9+&@#/%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%=~_()|]"); // https://blog.codinghorror.com/the-problem-with-urls/
+    private final HttpClient httpClient = HttpClient.newHttpClient();
     private final ViaEduardBot bot;
 
     public LogListener(final ViaEduardBot bot) {
@@ -38,12 +35,13 @@ public final class LogListener extends ListenerAdapter {
             return;
         }
 
-        if (Arrays.stream(allowedChannels).noneMatch(event.getGuildChannel().getName()::equals)) {
+        long channelId = event.getGuildChannel().getIdLong();
+        if (channelId != bot.getPluginSupportChannelId() && channelId != bot.getBotChannelId()) {
             return;
         }
 
         String data = event.getMessage().getContentRaw();
-        Matcher matcher = urlPattern.matcher(data);
+        Matcher matcher = URL_PATTERN.matcher(data);
         StringBuilder output = new StringBuilder();
 
         while (matcher.find()) {
@@ -51,38 +49,46 @@ public final class LogListener extends ListenerAdapter {
             int matchEnd = matcher.end();
             String match = data.substring(matchStart, matchEnd);
 
-            //cleanup the url
+            // Clean up the url
             if (match.startsWith("(") && match.endsWith(")")) {
                 match = match.substring(1, match.length() - 2);
             }
 
-            //filter out sites which are 100% not a paste-site
-            if (Arrays.stream(blacklist).noneMatch(match::startsWith)) {
-                System.out.println(match);
-                HttpRequest request = HttpRequest.newBuilder()
-                    .POST(HttpRequest.BodyPublishers.ofString("{\"url\":\"" + match + "\"}"))
-                    .uri(URI.create("https://athena.viaversion.workers.dev/v0/analyze/url"))
-                    .header("Content-Type", "application/json").header("User-Agent", "Eduard")
-                    .timeout(Duration.ofSeconds(2))
-                    .build();
-                try {
-                    HttpResponse<String> response = HttpClient.newHttpClient()
-                        .send(request, HttpResponse.BodyHandlers.ofString());
-                    if (response.statusCode() == 200) {
-                        final JsonObject object = ViaEduardBot.GSON.fromJson(response.body(), JsonObject.class);
-                        JsonArray tags = object.getAsJsonArray("tags");
-                        if (!tags.isEmpty()) {
-                            output.append(match).append(" ").append(object).append("\n");
-                        }
-                    }
-                } catch (IOException | InterruptedException e) {
-                    e.printStackTrace();
-                }
+            // Filter out sites which are 100% not a paste-site
+            if (BLACKLIST.stream().anyMatch(match::startsWith)) {
+                continue;
+            }
+
+            JsonObject body = new JsonObject();
+            body.addProperty("url", match);
+            HttpRequest request = HttpRequest.newBuilder()
+                .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
+                .uri(URI.create("https://athena.viaversion.workers.dev/v0/analyze/url"))
+                .header("Content-Type", "application/json").header("User-Agent", "Eduard")
+                .timeout(Duration.ofSeconds(2))
+                .build();
+            try {
+                sendRequest(request, output, match);
+            } catch (IOException | InterruptedException e) {
+                e.printStackTrace();
+                break;
             }
         }
+
         if (output.length() > 0) {
             bot.getGuild().getChannelById(TextChannel.class, bot.getBotChannelId()).sendMessage(event.getMessage().getJumpUrl() + output).queue();
             event.getMessage().addReaction(Emoji.fromUnicode("U+1FAB5")).queue();
+        }
+    }
+
+    private void sendRequest(HttpRequest request, StringBuilder output, String match) throws IOException, InterruptedException {
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() == 200) {
+            JsonObject object = ViaEduardBot.GSON.fromJson(response.body(), JsonObject.class);
+            JsonArray tags = object.getAsJsonArray("tags");
+            if (!tags.isEmpty()) {
+                output.append(match).append(' ').append(object).append('\n');
+            }
         }
     }
 }

--- a/src/main/java/com/viaversion/eduard/listener/LogListener.java
+++ b/src/main/java/com/viaversion/eduard/listener/LogListener.java
@@ -1,0 +1,88 @@
+package com.viaversion.eduard.listener;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import org.jetbrains.annotations.NotNull;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.viaversion.eduard.ViaEduardBot;
+
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public final class LogListener extends ListenerAdapter {
+    String[] blacklist = new String[]{"https://ci.viaversion.com", "https://dump.viaversion.com", "https://github.com", "https://modrinth.com", "https://hangar.papermc.io", "https://viaversion.com"};
+    String[] allowedChannels = new String[]{"plugin-support", "bot-test"};
+    Pattern urlPattern = Pattern.compile("\\(?\\bhttps://[-A-Za-z0-9+&@#/%?=~_()|!:,.;]*[-A-Za-z0-9+&@#/%=~_()|]");//https://blog.codinghorror.com/the-problem-with-urls/
+    private final ViaEduardBot bot;
+
+    public LogListener(final ViaEduardBot bot) {
+        this.bot = bot;
+    }
+
+    @Override
+    public void onMessageReceived(@NotNull final MessageReceivedEvent event) {
+        if (!event.isFromGuild() || !event.isFromType(ChannelType.TEXT) || event.isWebhookMessage() || event.getAuthor().isBot()) {
+            return;
+        }
+
+        if (Arrays.stream(allowedChannels).noneMatch(event.getGuildChannel().getName()::equals)) {
+            return;
+        }
+
+        String data = event.getMessage().getContentRaw();
+        Matcher matcher = urlPattern.matcher(data);
+        StringBuilder output = new StringBuilder();
+
+        while (matcher.find()) {
+            int matchStart = matcher.start();
+            int matchEnd = matcher.end();
+            String match = data.substring(matchStart, matchEnd);
+
+            //cleanup the url
+            if (match.startsWith("(") && match.endsWith(")")) {
+                match = match.substring(1, match.length() - 2);
+            }
+
+            //filter out sites which are 100% not a paste-site
+            if (Arrays.stream(blacklist).noneMatch(match::startsWith)) {
+                System.out.println(match);
+                HttpRequest request = HttpRequest.newBuilder()
+                    .POST(HttpRequest.BodyPublishers.ofString("{\"url\":\"" + match + "\"}"))
+                    .uri(URI.create("https://athena.viaversion.workers.dev/v0/analyze/url"))
+                    .header("Content-Type", "application/json").header("User-Agent", "Eduard")
+                    .timeout(Duration.ofSeconds(2))
+                    .build();
+                try {
+                    HttpResponse<String> response = HttpClient.newHttpClient()
+                        .send(request, HttpResponse.BodyHandlers.ofString());
+                    if (response.statusCode() == 200) {
+                        final JsonObject object = ViaEduardBot.GSON.fromJson(response.body(), JsonObject.class);
+                        JsonArray tags = object.getAsJsonArray("tags");
+                        if (!tags.isEmpty()) {
+                            output.append(match).append(" ").append(object).append("\n");
+                        }
+                    }
+                } catch (IOException | InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        if (output.length() > 0) {
+            bot.getGuild().getChannelById(TextChannel.class, bot.getBotChannelId()).sendMessage(event.getMessage().getJumpUrl() + output).queue();
+            event.getMessage().addReaction(Emoji.fromUnicode("U+1FAB5")).queue();
+        }
+    }
+}


### PR DESCRIPTION
Basic Athena Implementation which outputs the result in the bot-test channel (currently raw JSON, will be later replaced with propper embeds).
Has a basic blacklist to dont waste requests for sites which are 100% not a paste site (e.g. ci.viaversion.com), real whitelist is handled by Athena

![grafik](https://github.com/user-attachments/assets/793b6f25-1552-412b-8e15-55ceb5053c97)
![grafik](https://github.com/user-attachments/assets/e1edb815-27ab-4c95-8fc6-931758bd4693)
