### PR TITLE
Delete messages in bot-spam after 5min (except from stuff)

### DIFF
--- a/src/main/java/com/viaversion/eduard/ViaEduardBot.java
+++ b/src/main/java/com/viaversion/eduard/ViaEduardBot.java
@@ -11,6 +11,7 @@ import com.viaversion.eduard.command.ReloadMessagesCommand;
 import com.viaversion.eduard.command.ScanDumpsCommand;
 import com.viaversion.eduard.command.SetVersionCommand;
 import com.viaversion.eduard.command.base.CommandHandler;
+import com.viaversion.eduard.listener.BotSpamListener;
 import com.viaversion.eduard.listener.DumpMessageListener;
 import com.viaversion.eduard.listener.ErrorHelper;
 import com.viaversion.eduard.listener.FileMessageListener;
@@ -59,6 +60,7 @@ public final class ViaEduardBot {
     private final Guild guild;
     private long serverId;
     private long botChannelId;
+    private long botSpamChannelId;
     private long pluginSupportChannelId;
     private long modSupportChannelId;
     private long proxySupportChannelId;
@@ -95,7 +97,8 @@ public final class ViaEduardBot {
             .addEventListeners(new FileMessageListener(this))
             .addEventListeners(new SupportMessageListener(this))
             .addEventListeners(new ErrorHelper(this, object.getAsJsonObject("error-helper")))
-            .addEventListeners(new LogListener(this));
+            .addEventListeners(new LogListener(this))
+            .addEventListeners(new BotSpamListener(this));
 
         try {
             jda = builder.build().awaitReady();
@@ -158,6 +161,7 @@ public final class ViaEduardBot {
             .stream().map(JsonElement::getAsLong).collect(java.util.stream.Collectors.toSet());
         staffRoleId = object.getAsJsonPrimitive("staff-role").getAsLong();
         botChannelId = object.getAsJsonPrimitive("bot-channel").getAsLong();
+        botSpamChannelId = object.getAsJsonPrimitive("bot-spam").getAsLong();
         messageUrl = object.getAsJsonPrimitive("message-url").getAsString();
         return object;
     }
@@ -244,6 +248,10 @@ public final class ViaEduardBot {
 
     public long getBotChannelId() {
         return botChannelId;
+    }
+
+    public long getBotSpamChannelId() {
+        return botSpamChannelId;
     }
 
     public long getPluginSupportChannelId() {

--- a/src/main/java/com/viaversion/eduard/listener/BotSpamListener.java
+++ b/src/main/java/com/viaversion/eduard/listener/BotSpamListener.java
@@ -1,0 +1,29 @@
+package com.viaversion.eduard.listener;
+
+import com.viaversion.eduard.ViaEduardBot;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+import java.util.concurrent.TimeUnit;
+
+public class BotSpamListener extends ListenerAdapter {
+    private final ViaEduardBot bot;
+
+    public BotSpamListener(final ViaEduardBot bot) {
+        this.bot = bot;
+    }
+
+    @Override
+    public void onMessageReceived(@NotNull final MessageReceivedEvent event) {
+        if (!event.isFromGuild() || !event.isFromType(ChannelType.TEXT) || event.getGuildChannel().getIdLong() != bot.getBotSpamChannelId()) {
+            return;
+        }
+
+        if (event.getMember().getRoles().stream().anyMatch(role -> role.getIdLong() == bot.getStaffRoleId())) {
+            return;
+        }
+
+        event.getMessage().delete().queueAfter(5, TimeUnit.MINUTES);
+    }
+}

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -2,6 +2,7 @@
   "token": "",
   "server-id": 316206679014244363,
   "bot-channel": 698483428915675186,
+  "bot-spam": 1301842375110295613,
   "plugin-support-channel": 316208160232701955,
   "mod-support-channel": 1112835241271373966,
   "proxy-support-channel": 1112837970844721342,


### PR DESCRIPTION
Deletes all messages (except from users with the stuff role) in #bot-spam after 5min.

Notes
- This requires a redeploy of the config.json
- This requires the manage message permission for Eduard