### PR TITLE
Better SupportChannel Redirect message

### DIFF
--- a/src/main/java/com/viaversion/eduard/ViaEduardBot.java
+++ b/src/main/java/com/viaversion/eduard/ViaEduardBot.java
@@ -211,7 +211,8 @@ public final class ViaEduardBot {
     }
 
     public void sendSupportChannelRedirect(final MessageChannel channel, final User user) {
-        channel.sendMessage("Please use one of the support channels for help " + user.getAsMention()).queue();
+        channel.sendMessage("Please use one of the support channels for help " + user.getAsMention()
+            + "\n**Pluginsupport** (Paper/Spigot/Velocity...) <#316208160232701955>\n**Modsupport** (Fabric/Forge) <#1112835241271373966>\n**Standalone Appsupport** (VIAaaS/ViaProxy) <#1112837970844721342>").queue();
     }
 
     public @Nullable CommandHandler getCommand(final String command) {

--- a/src/main/java/com/viaversion/eduard/ViaEduardBot.java
+++ b/src/main/java/com/viaversion/eduard/ViaEduardBot.java
@@ -211,8 +211,13 @@ public final class ViaEduardBot {
     }
 
     public void sendSupportChannelRedirect(final MessageChannel channel, final User user) {
-        channel.sendMessage("Please use one of the support channels for help " + user.getAsMention()
-            + "\n**Pluginsupport** (Paper/Spigot/Velocity...) <#" + pluginSupportChannelId + ">\n**Modsupport** (Fabric/Forge) <#" + modSupportChannelId + ">\n**Standalone Appsupport** (VIAaaS/ViaProxy) <#" + proxySupportChannelId + ">").queue();
+        channel.sendMessage("""
+            Please use one of the support channels for help %s
+            **Plugin support** (Paper/Spigot/Velocity...) <#%d>
+            **Mod support** (Fabric/Forge) <#%d>
+            **Standalone App support** (VIAaaS/ViaProxy) <#%d>"""
+            .formatted(user.getAsMention(), pluginSupportChannelId, modSupportChannelId, proxySupportChannelId)
+        ).queue();
     }
 
     public @Nullable CommandHandler getCommand(final String command) {

--- a/src/main/java/com/viaversion/eduard/ViaEduardBot.java
+++ b/src/main/java/com/viaversion/eduard/ViaEduardBot.java
@@ -212,7 +212,7 @@ public final class ViaEduardBot {
 
     public void sendSupportChannelRedirect(final MessageChannel channel, final User user) {
         channel.sendMessage("Please use one of the support channels for help " + user.getAsMention()
-            + "\n**Pluginsupport** (Paper/Spigot/Velocity...) <#316208160232701955>\n**Modsupport** (Fabric/Forge) <#1112835241271373966>\n**Standalone Appsupport** (VIAaaS/ViaProxy) <#1112837970844721342>").queue();
+            + "\n**Pluginsupport** (Paper/Spigot/Velocity...) <#" + pluginSupportChannelId + ">\n**Modsupport** (Fabric/Forge) <#" + modSupportChannelId + ">\n**Standalone Appsupport** (VIAaaS/ViaProxy) <#" + proxySupportChannelId + ">").queue();
     }
 
     public @Nullable CommandHandler getCommand(final String command) {


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/2a3c047c-0945-426b-a3f2-5b8542a44e21)
As people often complain about now seeing/knowing about the different support channels, I adjusted the message to show all channel directly